### PR TITLE
Remove command_aliases and replace with additional_commands

### DIFF
--- a/lib/ChatCommands/vehicle/paint.lua
+++ b/lib/ChatCommands/vehicle/paint.lua
@@ -5,7 +5,7 @@ local vehicle_utils = require("chat_commander/vehicle_utils")
 
 return {
     command="paint",
-    command_aliases={"color"},
+    additional_commands={"color"},
     group="vehicle",
 	help="Paint the vehicle. Accepts color names or exact hexcodes. !paint blue, !paint #ff3344",
     execute=function(pid, commands)

--- a/lib/ChatCommands/vehicle/repair.lua
+++ b/lib/ChatCommands/vehicle/repair.lua
@@ -5,7 +5,7 @@ local vehicle_utils = require("chat_commander/vehicle_utils")
 
 return {
     command="repair",
-    command_aliases={"fix"},
+    additional_commands={"fix"},
     group="vehicle",
     help="Repair any damage done to your current vehicle",
     execute=function(pid, commands)


### PR DESCRIPTION
Fixed typo command_aliases and renamed to additional_commands